### PR TITLE
perf(split grid): split gird folder instead of grid files

### DIFF
--- a/pollination/annual_daylight/entry.py
+++ b/pollination/annual_daylight/entry.py
@@ -42,6 +42,13 @@ class AnnualDaylightEntryPoint(DAG):
         spec={'type': 'integer', 'minimum': 1}
     )
 
+    sensor_count = Inputs.int(
+        description='Minimum number of sensors in each sensor grid after redistributing '
+        'the sensors based on cpu_count. Use this value to ensure the parallelization '
+        'does not result in generating very small sensor grids. The default value is '
+        'set to 1.', defult=1, spec={'type': 'integer', 'minimum': 1}
+    )
+
     radiance_parameters = Inputs.str(
         description='The radiance parameters for ray tracing.',
         default='-ab 2 -ad 5000 -lw 2e-05',
@@ -135,7 +142,7 @@ class AnnualDaylightEntryPoint(DAG):
     )
     def split_grid_folder(
         self, input_folder=create_rad_folder._outputs.model_folder,
-        grid_count=cpu_count, sensor_count=1000
+        grid_count=cpu_count, sensor_count=sensor_count
         ):
         """Split sensor grid folder based on the number of CPUs."""
         return [

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-pollination-honeybee-radiance==0.12.8
+pollination-honeybee-radiance==0.14.0
 pollination-alias==0.9.2


### PR DESCRIPTION
This commit takes advantage of the newly added functions to `honeybee-radiance` to improve the performance of the recipe.

A test with a medium-size model on a local computer cut the run time by 25% and decreased the number of tasks from 568 to 140 tasks! This can result in a major boost in the performance of Pollination by decreasing the need to starting up new pods.

Once/if this PR gets merged we probably want to do the same with the other recipes. This approach removes the need to input the strange `sensor_count` number and can help to reuse the recipes inside other recipes with more control on the resources.

Unfortunately, I couldn't update the annual metrics section this time but we can revise that once the new `honeybee-radiance-postprocess` is ready.

I submit this PR as a draft since we need to merge [this PR](https://github.com/pollination/honeybee-radiance/pull/184) first and double-check the version of pollination-honeybee-radiance before merging this one.