### PR TITLE
ci: Fetch all git history for production deployment

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -88,6 +88,8 @@ jobs:
     if: github.ref == 'refs/heads/production' && github.repository_owner == 'pollination'
     steps:
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
       - name: set up Python
         uses: actions/setup-python@v2
         with:
@@ -95,7 +97,9 @@ jobs:
       - name: Get Job Context
         id: get-context
         run: |
-          echo "::set-output name=tag::$(git describe --tags | sed 's/v//')"
+          TAG=$(git describe --tags | sed 's/v//')
+          echo "Releasing tag: ${TAG:?}"
+          echo "::set-output name=tag::$TAG"
       - name: install python dependencies
         run: |
           pip install pollination-annual-daylight


### PR DESCRIPTION
By default the `actions/checkout` behavior is to fetch **only** the specified commit. No tags, no history, etc. Because of this, the step to get the tag for production was failing silently [here](https://github.com/pollination/annual-daylight/runs/4247081022?check_suite_focus=true#step:4:7).

- Add `fetch-depth: 0` to get all history in the `deploy-to-production` job.
- Add echo-or-fail to `get-context` that will be used in future steps to fail nosily if this re-appears for some reason.

Re: #110 #105 