### PR TITLE
fix(direct): Add support for direct illuminance results next to total

### DIFF
--- a/pollination/annual_daylight/_raytracing.py
+++ b/pollination/annual_daylight/_raytracing.py
@@ -65,18 +65,20 @@ class AnnualDaylightRayTracing(DAG):
     @task(template=DaylightContribution)
     def direct_sunlight(
         self,
+        name=grid_name,
         radiance_parameters=radiance_parameters,
-        fixed_radiance_parameters='-aa 0.0 -I -faf -ab 0 -dc 1.0 -dt 0.0 -dj 0.0 -dr 0',
+        fixed_radiance_parameters='-aa 0.0 -I -ab 0 -dc 1.0 -dt 0.0 -dj 0.0 -dr 0',
         sensor_count=sensor_count,
         modifiers=sun_modifiers,
         sensor_grid=sensor_grid,
+        output_format='a',  # make it ascii so we expose the file as a separate output
         scene_file=octree_file_with_suns,
         bsdf_folder=bsdfs
     ):
         return [
             {
                 'from': DaylightContribution()._outputs.result_file,
-                'to': 'direct_sunlight.ill'
+                'to': '../final/direct/{{self.name}}.ill'
             }
         ]
 
@@ -131,6 +133,6 @@ class AnnualDaylightRayTracing(DAG):
         return [
             {
                 'from': AddRemoveSkyMatrix()._outputs.results_file,
-                'to': '../final/{{self.name}}.ill'
+                'to': '../final/total/{{self.name}}.ill'
             }
         ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
-pollination-honeybee-radiance==0.15.1
-pollination-alias==0.9.12
+pollination-honeybee-radiance==0.16.4
+pollination-alias==0.9.13
+pollination-path==0.3.0


### PR DESCRIPTION
We already store the direct results in the annual-irradiance recipe and I figured that we are eventually going to want the same here when we add support for ASE. Given that some advanced users were asking for these direct results for use in their own glare potential methods and they know better that these results aren't suitable for LEED ASE, I am just adding some tasks that reconstruct the direct result matrices. All of these tweaks are purely under the hood and I didn't change any of the outputs. We can think of this as just a pre-step for the eventual support of ASE when we finally have window groups supported.