### PR TITLE
ci(action): run releases to pollination in sequences

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -68,6 +68,7 @@ jobs:
       fail-fast: true
       matrix:
         branch: [full, viz]
+      max-parallel: 1
     steps:
       - uses: actions/checkout@v2
         with:
@@ -150,6 +151,7 @@ jobs:
       fail-fast: true
       matrix:
         branch: [full, viz]
+      max-parallel: 1
     steps:
       - uses: actions/checkout@v2
         with:


### PR DESCRIPTION
This change will ensure that the full version is released first and then the viz version will be released.
