### PR TITLE
fix(postprocess): Use only metrics folder in GroupedDAG

### DIFF
--- a/pollination/annual_daylight/_post_process.py
+++ b/pollination/annual_daylight/_post_process.py
@@ -31,10 +31,7 @@ class AnnualDaylightPostProcess(GroupedDAG):
     )
 
     @task(
-        template=MergeFolderMetrics,
-        sub_paths={
-            'input_folder': 'metrics'
-        }
+        template=MergeFolderMetrics
     )
     def restructure_metrics(
         self, input_folder=initial_results,

--- a/pollination/annual_daylight/entry.py
+++ b/pollination/annual_daylight/entry.py
@@ -160,7 +160,7 @@ class AnnualDaylightEntryPoint(DAG):
         }
     )
     def post_process_annual_daylight(
-        self, initial_results='initial_results',
+        self, initial_results='initial_results/metrics',
         dist_info=prepare_folder_annual_daylight._outputs.resources,
         grids_info=prepare_folder_annual_daylight._outputs.results,
         model=model


### PR DESCRIPTION
This will speed up the post-processing when using the default or `-viz` version.